### PR TITLE
added ',' to cloning tutorial, fixing a syntax error

### DIFF
--- a/woof/cloning-tutorial.html
+++ b/woof/cloning-tutorial.html
@@ -79,7 +79,7 @@ var app = new Vue({
 			},
 			{
 				text: "2) Make a sprite that starts at a random spot on the left edge of the screen. You'll probably use code like this: ",
-				code: "var ghost = new Circle({\n  color: \"white\",\n  radius: 20,\n  x: minX\n  y: randomY()\n})",
+				code: "var ghost = new Circle({\n  color: \"white\",\n  radius: 20,\n  x: minX,\n  y: randomY()\n})",
 				url: "./snippets/cloning-tutorial-step2.html"
 			},
 			{


### PR DESCRIPTION
correcting syntax error by adding a comma in example code as per this issue: https://github.com/stevekrouse/WoofJS/issues/517 